### PR TITLE
feat: Smart search button

### DIFF
--- a/components/TopNav/index.js
+++ b/components/TopNav/index.js
@@ -129,13 +129,11 @@ function Navbar({ user }) {
               )
             }
             <button onClick={handleSmart} className="text-white bg-[#4aa7c0] w-4/5 px-5 py-2 text-2xl  space-x-4 my-2 rounded hover:bg-[#34778a] font-semibold transition-colors duration-100">
-                  Descubre
-                  <svg className="float-right mt-1 ml-1 h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-                  </svg>
+              Smart Search
+              <svg className="float-right mt-1 ml-1 h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z" />
+              </svg>
             </button>
-
-
           </section>
           <section className="row-span-4 space-y-0.5">
             <div className="mx-6 border-t-2" />

--- a/components/TopNav/index.js
+++ b/components/TopNav/index.js
@@ -27,6 +27,11 @@ function Navbar({ user }) {
     isLogged.role === 'USER' ? alert('Tienes que verificarte') : router.push("/publish/add");
     setIsOpen(false);
   }
+
+  const handleSmart = () => {
+    router.push("/smartsearch")
+  }
+
   return (
     <nav className="bg-gray-100 fixed top-0 inset-x-0 h-16 z-50 w-screen">
       <section className="shadow-lg mx-auto px-4">
@@ -123,6 +128,12 @@ function Navbar({ user }) {
                 </button>
               )
             }
+            <button onClick={handleSmart} className="text-white bg-[#4aa7c0] w-4/5 px-5 py-2 text-2xl  space-x-4 my-2 rounded hover:bg-[#34778a] font-semibold transition-colors duration-100">
+                  Descubre
+                  <svg className="float-right mt-1 ml-1 h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+                  </svg>
+            </button>
 
 
           </section>

--- a/pages/index.js
+++ b/pages/index.js
@@ -19,6 +19,9 @@ export default function Home() {
     e.preventDefault();
     router.push(`/search?q=${search}`);
   };
+  const handleSmart = () => {
+    router.push("/smartsearch");
+  }
 
   return (
     <div>
@@ -30,7 +33,18 @@ export default function Home() {
         {/* Seachbar */}
         <div className="w-full h-full hidden md:grid md:grid-rows-2 lg:grid-cols-3 lg:grid-rows-1">
           <div className="imageBackground md:row-span-2 lg:col-span-2 h-full">
-            <div className="top-1/2 left-1/4 relative">
+            {/* SmartSearch*/}
+            <div className="flex justify-end m-3 top-1/5 left-1/5">
+                <button 
+                onClick={handleSmart}
+                className="rounded-full bg-white transition duration-150 ease-in-out border-2 border-blue-bondi hover:border-blue-bondi-dark hover:bg-blue-bondi-dark text-blue-bondi hover:text-white font-bold py-5 px-8 focus:outline-none focus:shadow-outline">
+                  Smart Search
+                  <svg className="float-right ml-2 h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+                  </svg>
+                </button> 
+            </div>
+            <div className="top-1/3 left-1/4 relative">
               <div className="w-3/5 opacity-85">
                 <form onSubmit={handleSubmit}>
                   <div className="w-4/5 float-left">

--- a/pages/index.js
+++ b/pages/index.js
@@ -35,14 +35,14 @@ export default function Home() {
           <div className="imageBackground md:row-span-2 lg:col-span-2 h-full">
             {/* SmartSearch*/}
             <div className="flex justify-end m-3 top-1/5 left-1/5">
-                <button 
+              <button
                 onClick={handleSmart}
                 className="rounded-full bg-white transition duration-150 ease-in-out border-2 border-blue-bondi hover:border-blue-bondi-dark hover:bg-blue-bondi-dark text-blue-bondi hover:text-white font-bold py-5 px-8 focus:outline-none focus:shadow-outline">
-                  Smart Search
-                  <svg className="float-right ml-2 h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-                  </svg>
-                </button> 
+                Smart Search
+                <svg className="float-right h-6 w-6 ml-1" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z" />
+                </svg>
+              </button>
             </div>
             <div className="top-1/3 left-1/4 relative">
               <div className="w-3/5 opacity-85">


### PR DESCRIPTION
Al final he dejado la lupa como svg, ambos botones hacen su respectivo router.push("/smartsearch").
Visualmente queda:

- Versión de escritorio:

![imagen](https://user-images.githubusercontent.com/16075645/159131970-402b1976-2863-4775-9f2a-7b221318b59c.png)
![imagen](https://user-images.githubusercontent.com/16075645/159131997-a0e422a2-7500-4f67-a3fa-d7b8a75fe941.png)

- Version móvil:
![imagen](https://user-images.githubusercontent.com/16075645/159132027-5f787345-87f0-4ee0-a46d-ed04882f6d61.png)

